### PR TITLE
link fixes due to migration

### DIFF
--- a/.vitepress/config.mts
+++ b/.vitepress/config.mts
@@ -443,7 +443,7 @@ export default defineConfig({
     siteTitle: 'Iroha 2',
 
     socialLinks: [
-      { icon: 'github', link: 'https://github.com/hyperledger/iroha-2-docs' },
+      { icon: 'github', link: 'https://github.com/hyperledger-iroha/iroha-2-docs' },
       {
         icon: {
           /**
@@ -451,12 +451,12 @@ export default defineConfig({
            */
           svg: `<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 24 24"><path fill="currentColor" d="M12 21q-1.625 0-3.013-.8T6.8 18H4.975q-.425 0-.7-.288T4 17q0-.425.288-.713T5 16h1.1q-.075-.5-.088-1T6 14H4.975q-.425 0-.7-.288T4 13q0-.425.288-.713T5 12h1q0-.5.013-1t.087-1H4.975q-.425 0-.7-.288T4 9q0-.425.288-.713T5 8h1.8q.35-.575.788-1.075T8.6 6.05l-.925-.95q-.275-.3-.263-.713T7.7 3.7q.275-.275.7-.275t.7.275l1.45 1.45q.7-.225 1.425-.225t1.425.225l1.5-1.475q.3-.275.713-.262t.687.287q.275.275.275.7t-.275.7l-.95.95q.575.375 1.038.863T17.2 8h1.825q.425 0 .7.288T20 9q0 .425-.288.713T19 10h-1.1q.075.5.088 1T18 12h1.025q.425 0 .7.288T20 13q0 .425-.288.713T19 14h-1q0 .5-.013 1t-.087 1h1.125q.425 0 .7.288T20 17q0 .425-.288.713T19 18h-1.8q-.8 1.4-2.188 2.2T12 21Zm0-2q1.65 0 2.825-1.175T16 15v-4q0-1.65-1.175-2.825T12 7q-1.65 0-2.825 1.175T8 11v4q0 1.65 1.175 2.825T12 19Zm-1-3h2.025q.425 0 .7-.288T14 15q0-.425-.288-.713T13 14h-2.025q-.425 0-.7.288T10 15q0 .425.288.713T11 16Zm0-4h2.025q.425 0 .7-.288T14 11q0-.425-.288-.713T13 10h-2.025q-.425 0-.7.288T10 11q0 .425.288.713T11 12Zm1 1Z"/></svg>`,
         },
-        link: 'https://github.com/hyperledger/iroha-2-docs/issues/new',
+        link: 'https://github.com/hyperledger-iroha/iroha-2-docs/issues/new',
       },
     ],
 
     editLink: {
-      pattern: 'https://github.com/hyperledger/iroha-2-docs/edit/main/src/:path',
+      pattern: 'https://github.com/hyperledger-iroha/iroha-2-docs/edit/main/src/:path',
       text: 'Edit this page on GitHub',
     },
 

--- a/README.md
+++ b/README.md
@@ -1,18 +1,18 @@
 # Hyperledger Iroha 2 Tutorial
 
-This repository contains the source files for [Hyperledger Iroha 2 Documentation](https://hyperledger.github.io/iroha-2-docs/).
+This repository contains the source files for [Hyperledger Iroha 2 Documentation](https://docs.iroha.tech/).
 
 The tutorial is suitable for both experienced and novice users. It explains Iroha 2 concepts and features, and also offers language-specific step-by-step guides for these programming languages:
 
-- [CLI](https://hyperledger.github.io/iroha-2-docs/guide/operate-iroha-2-via-cli.html)
-- [Python](https://hyperledger.github.io/iroha-2-docs/guide/python.html)
-- [Rust](https://hyperledger.github.io/iroha-2-docs/guide/rust.html)
-- [Kotlin/Java](https://hyperledger.github.io/iroha-2-docs/guide/kotlin-java.html)
-- [Javascript (TypeScript)](https://hyperledger.github.io/iroha-2-docs/guide/javascript.html)
+- [CLI](https://docs.iroha.tech/get-started/operate-iroha-2-via-cli.html)
+- [Python](https://docs.iroha.tech/guide/tutorials/python.html)
+- [Rust](https://docs.iroha.tech/guide/tutorials/rust.html)
+- [Kotlin/Java](https://docs.iroha.tech/guide/tutorials/kotlin-java.html)
+- [Javascript (TypeScript)](https://docs.iroha.tech/guide/tutorials/javascript.html)
 
-If you are already familiar with Hyperledger Iroha, we invite you to read about [how Iroha 2 is different](https://hyperledger.github.io/iroha-2-docs/get-started/iroha-2.html) from its previous version.
+If you are already familiar with Hyperledger Iroha, we invite you to read about [how Iroha 2 is different](https://docs.iroha.tech/get-started/iroha-2.html) from its previous version.
 
-Check the [Hyperledger Iroha](https://github.com/hyperledger/iroha/) repository for more detailed information about API and available features.
+Check the [Hyperledger Iroha](https://github.com/hyperledger-iroha/iroha/) repository for more detailed information about API and available features.
 
 ## Contribution
 

--- a/etc/meta.ts
+++ b/etc/meta.ts
@@ -1,14 +1,14 @@
 /**
- * hyperledger/iroha#iroha2-dev
+ * hyperledger-iroha/iroha#iroha2-dev
  */
 export const IROHA_REV_DEV = 'e7a605c1a926c319d214ef3825524ee6c2e9f076'
 
 /**
- * hyperledger/iroha-javascript#iroha2 (rc13)
+ * hyperledger-iroha/iroha-javascript#iroha2 (rc13)
  */
 export const IROHA_JS_REV = '9c630fab14f063962b2508ac60e49789a160e443'
 
 /**
- * hyperledger/iroha-java#iroha2-dev
+ * hyperledger-iroha/iroha-java#iroha2-dev
  */
 export const IROHA_JAVA_REV_DEV = 'e176225f935cc7f976d17384191ef0c0043ca0f6'

--- a/etc/schema/types.ts
+++ b/etc/schema/types.ts
@@ -1,5 +1,5 @@
 // FIXME: this file reflects types from `@iroha2/data-model-schema` package which isn't published yet
-//        https://github.com/hyperledger/iroha-javascript/pull/170
+//        https://github.com/hyperledger-iroha/iroha-javascript/pull/170
 
 export interface Schema {
   [type: string]: SchemaTypeDefinition

--- a/etc/snippet-sources.ts
+++ b/etc/snippet-sources.ts
@@ -94,7 +94,7 @@ const javascriptSnippets = [
     local: '9-blocks-stream.ts',
   },
 ].map<SnippetSourceDefinition>(({ src, local }) => ({
-  src: `https://raw.githubusercontent.com/hyperledger/iroha-javascript/${IROHA_JS_REV}/${src}`,
+  src: `https://raw.githubusercontent.com/hyperledger-iroha/iroha-javascript/${IROHA_JS_REV}/${src}`,
   filename: `js-sdk-${local}`,
 }))
 
@@ -102,11 +102,11 @@ const javascriptSnippets = [
 
 export default [
   {
-    src: `https://raw.githubusercontent.com/hyperledger/iroha/${IROHA_REV_DEV}/MAINTAINERS.md`,
+    src: `https://raw.githubusercontent.com/hyperledger-iroha/iroha/${IROHA_REV_DEV}/MAINTAINERS.md`,
     filename: 'iroha-maintainers.md',
   },
   {
-    src: `https://raw.githubusercontent.com/hyperledger/iroha/${IROHA_REV_DEV}/docs/source/references/schema.json`,
+    src: `https://raw.githubusercontent.com/hyperledger-iroha/iroha/${IROHA_REV_DEV}/docs/source/references/schema.json`,
     filename: `data-model-schema.md`,
     transform: (source) => {
       return renderDataModelSchema(JSON.parse(source))
@@ -116,31 +116,31 @@ export default [
     src: './src/example_code/lorem.rs',
   },
   {
-    src: `https://raw.githubusercontent.com/hyperledger/iroha/${IROHA_REV_DEV}/configs/client.template.toml`,
+    src: `https://raw.githubusercontent.com/hyperledger-iroha/iroha/${IROHA_REV_DEV}/configs/client.template.toml`,
     filename: 'client-cli-config-template.toml',
   },
   {
-    src: `https://raw.githubusercontent.com/hyperledger/iroha/${IROHA_REV_DEV}/configs/peer.template.toml`,
+    src: `https://raw.githubusercontent.com/hyperledger-iroha/iroha/${IROHA_REV_DEV}/configs/peer.template.toml`,
     filename: 'peer-config-template.toml',
   },
   {
-    src: `https://raw.githubusercontent.com/hyperledger/iroha/${IROHA_REV_DEV}/configs/swarm/genesis.json`,
+    src: `https://raw.githubusercontent.com/hyperledger-iroha/iroha/${IROHA_REV_DEV}/configs/swarm/genesis.json`,
   },
   {
-    src: `https://raw.githubusercontent.com/hyperledger/iroha/${IROHA_REV_DEV}/client/examples/tutorial.rs`,
+    src: `https://raw.githubusercontent.com/hyperledger-iroha/iroha/${IROHA_REV_DEV}/client/examples/tutorial.rs`,
     filename: 'tutorial-snippets.rs',
   },
 
   ...javascriptSnippets,
 
   {
-    src: `https://raw.githubusercontent.com/hyperledger/iroha-java/${IROHA_JAVA_REV_DEV}/modules/test-tools/src/main/kotlin/jp/co/soramitsu/iroha2/testengine/IrohaConfig.kt`,
+    src: `https://raw.githubusercontent.com/hyperledger-iroha/iroha-java/${IROHA_JAVA_REV_DEV}/modules/test-tools/src/main/kotlin/jp/co/soramitsu/iroha2/testengine/IrohaConfig.kt`,
     filename: 'IrohaConfig.kotlin',
   },
   {
-    src: `https://raw.githubusercontent.com/hyperledger/iroha-java/${IROHA_JAVA_REV_DEV}/modules/client/src/test/kotlin/jp/co/soramitsu/iroha2/InstructionsTest.kt`,
+    src: `https://raw.githubusercontent.com/hyperledger-iroha/iroha-java/${IROHA_JAVA_REV_DEV}/modules/client/src/test/kotlin/jp/co/soramitsu/iroha2/InstructionsTest.kt`,
   },
   {
-    src: `https://raw.githubusercontent.com/hyperledger/iroha-java/${IROHA_JAVA_REV_DEV}/modules/client/src/test/java/jp/co/soramitsu/iroha2/JavaTest.java`,
+    src: `https://raw.githubusercontent.com/hyperledger-iroha/iroha-java/${IROHA_JAVA_REV_DEV}/modules/client/src/test/java/jp/co/soramitsu/iroha2/JavaTest.java`,
   },
 ] satisfies SnippetSourceDefinition[]

--- a/src/blockchain/consensus.md
+++ b/src/blockchain/consensus.md
@@ -32,5 +32,5 @@ fail. The same thing happens if the peers have different instructions.
 
 [^1]:
     For prospective wizards, the
-    [Iroha 2 Whitepaper](https://github.com/hyperledger/iroha/blob/main/docs/source/iroha_2_whitepaper.md)
+    [Iroha 2 Whitepaper](https://github.com/hyperledger-iroha/iroha/blob/main/docs/source/iroha_2_whitepaper.md)
     is a good start.

--- a/src/blockchain/instructions.md
+++ b/src/blockchain/instructions.md
@@ -151,7 +151,7 @@ To do this, an account have to be granted the
 Refer to an example on how to
 transfer assets with [CLI](/get-started/operate-iroha-2-via-cli.md#_7-transfer-assets) or [Rust](/guide/tutorials/rust.md#_6-transferring-assets).
 
-<!--TODO: add links to transferring assets example in which guide after https://github.com/hyperledger/iroha-2-docs/issues/81 is addressed -->
+<!--TODO: add links to transferring assets example in which guide after https://github.com/hyperledger-iroha/iroha-2-docs/issues/81 is addressed -->
 
 ## Grant/Revoke
 

--- a/src/blockchain/triggers.md
+++ b/src/blockchain/triggers.md
@@ -19,7 +19,7 @@ contains the necessary information:
     The documentation on the `EventFilter` types is under construction, as
     we are likely to make major changes to that particular architecture.
     For now, suffice it to say that you can look at the
-    [source code](https://github.com/hyperledger/iroha/blob/main/data_model/src/events/data/filters.rs)
+    [source code](https://github.com/hyperledger-iroha/iroha/blob/main/data_model/src/events/data/filters.rs)
     in `iroha_data_model` and see a few particularly interesting
     applications.
 

--- a/src/blockchain/wasm.md
+++ b/src/blockchain/wasm.md
@@ -70,7 +70,7 @@ edition = "2021"
 crate-type = ['cdylib']
 
 [dependencies]
-iroha_wasm = { git = "https://github.com/hyperledger/iroha/"}
+iroha_wasm = { git = "https://github.com/hyperledger-iroha/iroha/"}
 ```
 
 Note that the crate type is `cdylib`. Most Rust code is linked in a

--- a/src/documenting/snippets.md
+++ b/src/documenting/snippets.md
@@ -9,13 +9,13 @@ located in other repositories, where they are built, run, and tested.
 ### Snippet Sources
 
 Snippet sources are defined in
-[`snippet_sources.ts`](https://github.com/hyperledger/iroha-2-docs/blob/main/etc/snippet-sources.ts).
+[`snippet_sources.ts`](https://github.com/hyperledger-iroha/iroha-2-docs/blob/main/etc/snippet-sources.ts).
 The `snippet_sources.ts` file is located in the documentation repository and has the following format:
 
 ```ts
 export default [
   {
-    src: 'https://raw.githubusercontent.com/hyperledger/iroha/main/MAINTAINERS.md',
+    src: 'https://raw.githubusercontent.com/hyperledger-iroha/iroha/main/MAINTAINERS.md',
     filename: 'iroha-maintainers-at-stable.md',
   },
   {
@@ -72,11 +72,11 @@ files into the documentation.
 ## Example
 
 Let's add a code snippet from Iroha JavaScript SDK. For example, this one:
-[`/packages/docs-recipes/src/1.client-install.ts`](https://github.com/hyperledger/iroha-javascript/blob/e300886e76c777776efad1e2f5cb245bfb8ed02e/packages/docs-recipes/src/1.client-install.ts).
+[`/packages/docs-recipes/src/1.client-install.ts`](https://github.com/hyperledger-iroha/iroha-javascript/blob/e300886e76c777776efad1e2f5cb245bfb8ed02e/packages/docs-recipes/src/1.client-install.ts).
 
 1. First, get a permalink to the file. Open the file on GitHub and click
    `Raw` button to get the link. For example:
-   https://raw.githubusercontent.com/hyperledger/iroha-javascript/e300886e76c777776efad1e2f5cb245bfb8ed02e/packages/docs-recipes/src/1.client-install.ts
+   https://raw.githubusercontent.com/hyperledger-iroha/iroha-javascript/e300886e76c777776efad1e2f5cb245bfb8ed02e/packages/docs-recipes/src/1.client-install.ts
 
 2. Define the new snippet in the [Snippet Sources](#snippet-sources):
 
@@ -85,7 +85,7 @@ Let's add a code snippet from Iroha JavaScript SDK. For example, this one:
      /// ...
 
      {
-       src: 'https://raw.githubusercontent.com/hyperledger/iroha-javascript/e300886e76c777776efad1e2f5cb245bfb8ed02e/packages/docs-recipes/src/1.client-install.ts',
+       src: 'https://raw.githubusercontent.com/hyperledger-iroha/iroha-javascript/e300886e76c777776efad1e2f5cb245bfb8ed02e/packages/docs-recipes/src/1.client-install.ts',
        filename: 'js-sdk-1-client-install.ts',
      },
    ]
@@ -117,7 +117,7 @@ Let's add a code snippet from Iroha JavaScript SDK. For example, this one:
      // ...
 
      {
-       src: `https://raw.githubusercontent.com/hyperledger/iroha/${IROHA_REV_STABLE}/MAINTAINERS.md`,
+       src: `https://raw.githubusercontent.com/hyperledger-iroha/iroha/${IROHA_REV_STABLE}/MAINTAINERS.md`,
        //                                                        ^^^^^^^^^^^^^^^^^^^
        filename: 'iroha-maintainers-at-stable.md',
      },

--- a/src/get-started/index.md
+++ b/src/get-started/index.md
@@ -38,13 +38,13 @@ Once you have learned the basics, we suggest exploring the following sections:
 ## Learn More
 
 For more information on Iroha, see the following:
-- [Iroha 2 Whitepaper](https://github.com/hyperledger/iroha/tree/main/docs/source/iroha_2_whitepaper.md)
+- [Iroha 2 Whitepaper](https://github.com/hyperledger-iroha/iroha/tree/main/docs/source/iroha_2_whitepaper.md)
 - [Hyperledger Foundation Wiki: Hyperledger Iroha > Iroha 2](https://wiki.hyperledger.org/display/iroha/Iroha+2)
 
 For more information on Iroha 1, see the official [Hyperledger Iroha documentation](https://iroha.readthedocs.io/en/develop/index.html).
 
 ::: tip
 
-If you want to contribute to Hyperledger Iroha, see the [Contributing Guide](https://github.com/hyperledger/iroha/blob/main/CONTRIBUTING.md).
+If you want to contribute to Hyperledger Iroha, see the [Contributing Guide](https://github.com/hyperledger-iroha/iroha/blob/main/CONTRIBUTING.md).
 
 :::

--- a/src/get-started/install-iroha-2.md
+++ b/src/get-started/install-iroha-2.md
@@ -52,10 +52,10 @@ Check the [OpenSSL installation guide](https://github.com/openssl/openssl/blob/m
    $ cd ~/Git
    ```
 
-3. Clone the [`iroha`](https://github.com/hyperledger/iroha) GitHub repository:
+3. Clone the [`iroha`](https://github.com/hyperledger-iroha/iroha) GitHub repository:
 
    ```bash
-   $ git clone https://github.com/hyperledger/iroha.git
+   $ git clone https://github.com/hyperledger-iroha/iroha.git
    ```
 
 ### 3. Install Iroha Binaries
@@ -65,11 +65,11 @@ To get started you need two of the binaries shipped with Iroha:
 - `iroha`, the main command line tool for accessing the Iroha network as a user. It allows you to manage domains, accounts, and assets, and to query network status and events. To install `iroha` system-wide, use the following command:
 
 ```bash
-$ cargo install --git https://github.com/hyperledger/iroha.git iroha_cli
+$ cargo install --git https://github.com/hyperledger-iroha/iroha.git iroha_cli
 ```
 
 - `kagami`, the tool that generates cryotpgraphic keys, configuration files and other necessary data. To install `kagami` system-wide, use the following command:
 
 ```bash
-$ cargo install --git https://github.com/hyperledger/iroha.git iroha_kagami
+$ cargo install --git https://github.com/hyperledger-iroha/iroha.git iroha_kagami
 ```

--- a/src/get-started/iroha-2.md
+++ b/src/get-started/iroha-2.md
@@ -16,7 +16,7 @@ Among other changes, cryptography and account structures are implemented differe
 
 ## Fault Tolerance
 
-Iroha 2 learned a great deal from the development of the original Iroha. Of particular importance is the new and improved Byzantine-fault-tolerant consensus algorithm—[_Sumeragi_](https://github.com/hyperledger/iroha/tree/main/docs/source/iroha_2_whitepaper.md#28-consensus)—that allowed us to expand what could be done on a blockchain without any security risks.
+Iroha 2 learned a great deal from the development of the original Iroha. Of particular importance is the new and improved Byzantine-fault-tolerant consensus algorithm—[_Sumeragi_](https://github.com/hyperledger-iroha/iroha/tree/main/docs/source/iroha_2_whitepaper.md#28-consensus)—that allowed us to expand what could be done on a blockchain without any security risks.
 
 ::: info
 

--- a/src/get-started/launch-iroha-2.md
+++ b/src/get-started/launch-iroha-2.md
@@ -10,7 +10,7 @@ To launch an instance of the Iroha 2 network, install the following first:
 
 ## 2. Launch Iroha Network
 
-1. In your terminal, navigate to the root directory of your local [`iroha`](https://github.com/hyperledger/iroha) repository:
+1. In your terminal, navigate to the root directory of your local [`iroha`](https://github.com/hyperledger-iroha/iroha) repository:
 
    ```bash
    $ cd ~/Git/iroha
@@ -45,7 +45,7 @@ The following options are also available for local compilation:
 
 ::: tip Note
 
-There is ongoing work to make our configurations for Docker even more customizable with the help of [Swarm](https://github.com/hyperledger/iroha/tree/main/tools/swarm).
+There is ongoing work to make our configurations for Docker even more customizable with the help of [Swarm](https://github.com/hyperledger-iroha/iroha/tree/main/crates/iroha_swarm).
 
 <!-- Check: a reference about future releases or work in progress -->
 

--- a/src/guide/advanced/metrics.md
+++ b/src/guide/advanced/metrics.md
@@ -10,14 +10,14 @@ See [Reference > Torii Endpoints: Metrics](../../reference/torii-endpoints.md#me
 
 ## How to use metrics
 
-<!-- TODO: Update this subtopic as part of PR #397: https://github.com/hyperledger/iroha-2-docs/pull/397 -->
+<!-- TODO: Update this subtopic as part of PR #397: https://github.com/hyperledger-iroha/iroha-2-docs/pull/397 -->
 
 Work in Progress.
 
 This topic will be updated as part of the new configuration reference.
 
 The progress on the configuration reference can be tracked in the following GitHub issue:\
-[iroha-2-docs > Issue #392: Tracking issue for Configuration Reference as per RFC](https://github.com/hyperledger/iroha-2-docs/issues/392).
+[iroha-2-docs > Issue #392: Tracking issue for Configuration Reference as per RFC](https://github.com/hyperledger-iroha/iroha-2-docs/issues/392).
 
 ::: note
 

--- a/src/guide/advanced/running-iroha-on-bare-metal.md
+++ b/src/guide/advanced/running-iroha-on-bare-metal.md
@@ -23,8 +23,8 @@ You can always check
 [peer configuration options](/guide/configure/peer-configuration.md) for
 more details.
 
-<!-- TODO: Add the new configuration reference, once its ready. Issue: https://github.com/hyperledger/iroha-2-docs/issues/392
-The full list of available options is in the [Iroha Configuration Reference](https://github.com/hyperledger/iroha/blob/iroha2-dev/docs/source/references/config.md). -->
+<!-- TODO: Add the new configuration reference, once its ready. Issue: https://github.com/hyperledger-iroha/iroha-2-docs/issues/392
+The full list of available options is in the [Iroha Configuration Reference](https://github.com/hyperledger-iroha/iroha/blob/iroha2-dev/docs/source/references/config.md). -->
 
 :::
 

--- a/src/guide/configure/configuration-types.md
+++ b/src/guide/configure/configuration-types.md
@@ -8,8 +8,8 @@ In this section we explain the difference between `Option<..>` and
 `Option<Option<..>>` used for configuration types. You can find more about
 available configuration options in the [Peer Configuration](peer-configuration.md) topic.
 
-<!-- TODO: Add the new configuration reference, once its ready. Issue: https://github.com/hyperledger/iroha-2-docs/issues/392
-The full list of available options is in the [Iroha Configuration Reference](https://github.com/hyperledger/iroha/blob/iroha2-dev/docs/source/references/config.md). -->
+<!-- TODO: Add the new configuration reference, once its ready. Issue: https://github.com/hyperledger-iroha/iroha-2-docs/issues/392
+The full list of available options is in the [Iroha Configuration Reference](https://github.com/hyperledger-iroha/iroha/blob/iroha2-dev/docs/source/references/config.md). -->
 
 ## `Option<..>`
 

--- a/src/guide/configure/keys-for-network-deployment.md
+++ b/src/guide/configure/keys-for-network-deployment.md
@@ -55,9 +55,9 @@ Finally, while the first client _could_ use the genesis account to register new 
 
 If you plan on creating a private blockchain, you should consider writing your own client based on the `client` Rust crate, or any of the provided client libraries:
 
-- [iroha-python](https://github.com/hyperledger/iroha-python)
-- [iroha-iOS](https://github.com/hyperledger/iroha-ios)
-- [iroha-java](https://github.com/hyperledger/iroha-java)
-- [iroha-javascript](https://github.com/hyperledger/iroha-javascript)
+- [iroha-python](https://github.com/hyperledger-iroha/iroha-python)
+- [iroha-iOS](https://github.com/hyperledger-iroha/iroha-ios)
+- [iroha-java](https://github.com/hyperledger-iroha/iroha-java)
+- [iroha-javascript](https://github.com/hyperledger-iroha/iroha-javascript)
 
 :::

--- a/src/guide/configure/peer-configuration.md
+++ b/src/guide/configure/peer-configuration.md
@@ -29,8 +29,8 @@ following:
 - [Public and private keys for the genesis account](#genesis)
   (`ACCOUNT_PUBLIC_KEY` and `ACCOUNT_PRIVATE_KEY`)
 
-  <!-- TODO: Add the new configuration reference, once its ready. Issue: https://github.com/hyperledger/iroha-2-docs/issues/392
-  The full list of available options is in the [Iroha Configuration Reference](https://github.com/hyperledger/iroha/blob/iroha2-dev/docs/source/references/config.md). -->
+  <!-- TODO: Add the new configuration reference, once its ready. Issue: https://github.com/hyperledger-iroha/iroha-2-docs/issues/392
+  The full list of available options is in the [Iroha Configuration Reference](https://github.com/hyperledger-iroha/iroha/blob/iroha2-dev/docs/source/references/config.md). -->
 
 ::: info
 
@@ -88,8 +88,8 @@ trusted peers:
 `TORII` is the module in charge of handling incoming and outgoing
 connections.
 
-<!-- TODO: Add the new configuration reference, once its ready. Issue: https://github.com/hyperledger/iroha-2-docs/issues/392
-The full list of available options is in the [Iroha Configuration Reference](https://github.com/hyperledger/iroha/blob/iroha2-dev/docs/source/references/config.md). -->
+<!-- TODO: Add the new configuration reference, once its ready. Issue: https://github.com/hyperledger-iroha/iroha-2-docs/issues/392
+The full list of available options is in the [Iroha Configuration Reference](https://github.com/hyperledger-iroha/iroha/blob/iroha2-dev/docs/source/references/config.md). -->
 
 ### `API_URL`
 
@@ -151,8 +151,8 @@ configurations, such as:
 - `GENESIS_SUBMISSION_DELAY_MS`: the delay before the genesis block
   submission after the minimum number of peers were discovered.
 
-<!-- TODO: Add the new configuration reference, once its ready. Issue: https://github.com/hyperledger/iroha-2-docs/issues/392
-The full list of available options is in the [Iroha Configuration Reference](https://github.com/hyperledger/iroha/blob/iroha2-dev/docs/source/references/config.md). -->
+<!-- TODO: Add the new configuration reference, once its ready. Issue: https://github.com/hyperledger-iroha/iroha-2-docs/issues/392
+The full list of available options is in the [Iroha Configuration Reference](https://github.com/hyperledger-iroha/iroha/blob/iroha2-dev/docs/source/references/config.md). -->
 
 ## Logger
 
@@ -200,5 +200,5 @@ _warehouse_). The `BLOCK_STORE_PATH` specifies where the blocks are stored.
 You can change it to a custom location if for some reason the default
 location (`./storage`) is not available or desirable.
 
-<!-- TODO: Add the new configuration reference, once its ready. Issue: https://github.com/hyperledger/iroha-2-docs/issues/392
-The full list of available options is in the [Iroha Configuration Reference](https://github.com/hyperledger/iroha/blob/iroha2-dev/docs/source/references/config.md). -->
+<!-- TODO: Add the new configuration reference, once its ready. Issue: https://github.com/hyperledger-iroha/iroha-2-docs/issues/392
+The full list of available options is in the [Iroha Configuration Reference](https://github.com/hyperledger-iroha/iroha/blob/iroha2-dev/docs/source/references/config.md). -->

--- a/src/guide/configure/peer-management.md
+++ b/src/guide/configure/peer-management.md
@@ -11,7 +11,7 @@ correct software and waiting until your node gets discovered.
 ::: info
 
 Peer discovery is
-[under construction](https://github.com/hyperledger/iroha/issues/1375 '#1375').
+[under construction](https://github.com/hyperledger-iroha/iroha/issues/1375 '#1375').
 
 <!-- Check: a reference about future releases or work in progress -->
 
@@ -59,7 +59,7 @@ After a new peer was granted permissions, it must be set up.
 It's a good idea to request information about the peers' configuration in
 the network. Your best friend is the `configuration` endpoint of the API
 socket. Thus far querying is done manually. Until the
-[bootstrapping procedure](https://github.com/hyperledger/iroha/issues/1184 '#1184')
+[bootstrapping procedure](https://github.com/hyperledger-iroha/iroha/issues/1184 '#1184')
 is implemented, you'll have to manually check that the timeouts and batch
 sizes match.
 

--- a/src/guide/configure/sample-configuration.md
+++ b/src/guide/configure/sample-configuration.md
@@ -2,9 +2,9 @@
 
 Here you can find sample configuration files for Iroha 2:
 
-- Genesis Block [`configs/peer/genesis.json`](https://github.com/hyperledger/iroha/blob/main/defaults/genesis.json).\
+- Genesis Block [`configs/peer/genesis.json`](https://github.com/hyperledger-iroha/iroha/blob/main/defaults/genesis.json).\
   For details, see [Genesis Block](genesis.md).
-- Client Configuration [`configs/client/config.json`](https://github.com/hyperledger/iroha/blob/main/defaults/client.toml).\
+- Client Configuration [`configs/client/config.json`](https://github.com/hyperledger-iroha/iroha/blob/main/defaults/client.toml).\
   For details, see [Client Configuration](client-configuration.md).
 
 ::: code-group

--- a/src/guide/tutorials/javascript.md
+++ b/src/guide/tutorials/javascript.md
@@ -36,7 +36,7 @@ the active development is happening. Clone the repository and check out the
 `iroha2` branch:
 
 ```bash
-$ git clone https://github.com/hyperledger/iroha-javascript.git --branch iroha2
+$ git clone https://github.com/hyperledger-iroha/iroha-javascript.git --branch iroha2
 ```
 
 Please note that this guide does not cover the details of this workflow.
@@ -403,7 +403,7 @@ in this guide!
 In this guide, we are roughly recreating the project that is a part of
 `iroha-javascript` integration tests. If you want to see the full project,
 please refer to the
-[`@iroha2/client-test-web` sources](https://github.com/hyperledger/iroha-javascript/tree/main/packages/client/test/integration/test-web).
+[`@iroha2/client-test-web` sources](https://github.com/hyperledger-iroha/iroha-javascript/tree/main/packages/client/test/integration/test-web).
 
 :::
 

--- a/src/guide/tutorials/kotlin-java.md
+++ b/src/guide/tutorials/kotlin-java.md
@@ -11,7 +11,7 @@ the unusual, and provide some instructions for creating your own Iroha
 We assume that you know how to create a new package and have basic
 understanding of the fundamental Kotlin code. Specifically, we shall assume
 that you know how to build and deploy your program on the target platforms.
-To clone Iroha 2 JVM compatible SDKs, you can use [Iroha Java](https://github.com/hyperledger/iroha-java).
+To clone Iroha 2 JVM compatible SDKs, you can use [Iroha Java](https://github.com/hyperledger-iroha/iroha-java).
 
 Without further ado, here's a part of an example `build.gradle.kts` file,
 specifically, the `plugins`, `repositories` and `dependencies` sections:
@@ -51,14 +51,14 @@ latest `iroha-java` snapshot.
 
 Snapshot versions match the Git commits. To get the latest snapshot, simply
 visit the
-[`iroha-java`](https://github.com/hyperledger/iroha-java/tree/iroha2-dev)
+[`iroha-java`](https://github.com/hyperledger-iroha/iroha-java/tree/iroha2-dev)
 repository on the `iroha-2-dev` branch and copy the short hash of the last
 commit on the main page.
 
 ![](/img/iroha_java_hash.png)
 
 You can also check the
-[commit history](https://github.com/hyperledger/iroha-java/commits/iroha2-dev)
+[commit history](https://github.com/hyperledger-iroha/iroha-java/commits/iroha2-dev)
 and copy the commit hash of a previous commit.
 
 ![](/img/iroha_java_commits.png)

--- a/src/guide/tutorials/python.md
+++ b/src/guide/tutorials/python.md
@@ -14,7 +14,7 @@ repository into it:
 
 ```bash
 $ cd ~/Git/
-$ git clone https://github.com/hyperledger/iroha-python/ --branch iroha2
+$ git clone https://github.com/hyperledger-iroha/iroha-python/ --branch iroha2
 $ cd iroha-python
 ```
 

--- a/src/guide/tutorials/rust.md
+++ b/src/guide/tutorials/rust.md
@@ -58,7 +58,7 @@ first.
 ::: info
 
 You could also make use of our `test_network` crate, which is available via
-[GitHub](https://github.com/hyperledger/iroha/tree/main/core/test_network)
+[GitHub](https://github.com/hyperledger-iroha/iroha/tree/main/core/test_network)
 but not via crates.io.
 
 :::

--- a/src/guide/tutorials/rust.md
+++ b/src/guide/tutorials/rust.md
@@ -58,7 +58,7 @@ first.
 ::: info
 
 You could also make use of our `test_network` crate, which is available via
-[GitHub](https://github.com/hyperledger-iroha/iroha/tree/main/core/test_network)
+[GitHub](https://github.com/hyperledger-iroha/iroha/tree/main/crates/iroha_test_network)
 but not via crates.io.
 
 :::

--- a/src/help/index.md
+++ b/src/help/index.md
@@ -4,4 +4,4 @@ From time to time, you may have questions about Iroha that you would like to dis
 
 A large part of the community currently uses [Telegram](https://t.me/hyperledgeriroha) for communication. The Hyperledger part of the team prefers [Discord](https://discord.gg/hyperledger), with two dedicated channels: `iroha` and `iroha-2-contributors`. The Discord and Telegram channels are synchronized, so users of both media see your messages.
 
-Finally, you can [create a GitHub issue](https://github.com/hyperledger/iroha/issues/new/choose), whether it's a request to update documentation, a suggestion for the core team, or a bug you have found.
+Finally, you can [create a GitHub issue](https://github.com/hyperledger-iroha/iroha/issues/new/choose), whether it's a request to update documentation, a suggestion for the core team, or a bug you have found.

--- a/src/index.md
+++ b/src/index.md
@@ -8,7 +8,7 @@ hero:
   #actions:
   #- theme: alt
   #  text: View on GitHub
-  #  link: https://github.com/hyperledger/iroha/tree/iroha2-dev
+  #  link: https://github.com/hyperledger-iroha/iroha/
 
 features:
   - icon: 🚀

--- a/src/reference/torii-endpoints.md
+++ b/src/reference/torii-endpoints.md
@@ -6,13 +6,13 @@ Messages for certain `TORII` operations are encoded with the Parity <abbr title=
 
 For more information on `SCALE`, see the [Substrate Documentation: Type encoding (SCALE)](https://docs.substrate.io/reference/scale-codec/) article and its [official GitHub repository](https://github.com/paritytech/parity-scale-codec).
 
-<!-- TODO: link to our own article about SCALE, once it is written; Issue: https://github.com/hyperledger/iroha-2-docs/issues/367 -->
+<!-- TODO: link to our own article about SCALE, once it is written; Issue: https://github.com/hyperledger-iroha/iroha-2-docs/issues/367 -->
 
 :::
 
 Torii (Japanese: 鳥居 — Shinto shrine gateway) is the Iroha 2 module in charge of handling `HTTP` and `WebSocket` requests. It is the main <abbr title="Application Programming Interface">API</abbr> for interacting with Iroha 2. Such interactions include sending transactions, making queries, listening for blocks stream, etc.
 
-<!-- TODO: Update the following as part of PR #397: https://github.com/hyperledger/iroha-2-docs/pull/397
+<!-- TODO: Update the following as part of PR #397: https://github.com/hyperledger-iroha/iroha-2-docs/pull/397
 
 To establish two-way communication with the `TORII` endpoints, the following addresses must be specified in the Iroha 2 configuration files:
 
@@ -46,7 +46,7 @@ To establish two-way communication with the `TORII` endpoints, the following add
 
 This operation requires the specific Iroha node being requested to be compiled with the `telemetry` feature enabled.
 
-<!-- TODO: Link to a topic about Iroha features/flags; Issue: https://github.com/hyperledger/iroha-2-docs/issues/465 -->
+<!-- TODO: Link to a topic about Iroha features/flags; Issue: https://github.com/hyperledger-iroha/iroha-2-docs/issues/465 -->
 
 :::
 
@@ -142,7 +142,7 @@ The list of all accepted values is currently unavailable and will be a part of t
 Until then, to get assistance with the acceptable values and their definitions, consult [Receive Support](/help/) for ways to contact us.
 
 The progress on the configuration reference can be tracked in the following GitHub issue:\
-[iroha-2-docs > Issue #392: Tracking issue for Configuration Reference as per RFC](https://github.com/hyperledger/iroha-2-docs/issues/392).
+[iroha-2-docs > Issue #392: Tracking issue for Configuration Reference as per RFC](https://github.com/hyperledger-iroha/iroha-2-docs/issues/392).
 
 :::
 
@@ -223,7 +223,7 @@ A `GET` request to the endpoint.
 
 This operation requires the Iroha 2 network to be established with the `telemetry` feature enabled.
 
-<!-- TODO: Link to a topic about Iroha features/flags; Issue: https://github.com/hyperledger/iroha-2-docs/issues/465 -->
+<!-- TODO: Link to a topic about Iroha features/flags; Issue: https://github.com/hyperledger-iroha/iroha-2-docs/issues/465 -->
 
 :::
 
@@ -381,7 +381,7 @@ Whether each prerequisite object was found and [`FindError`](/reference/data-mod
 
 This operation requires the Iroha 2 network to be established with the `schema` feature enabled.
 
-<!-- TODO: Link to a topic about Iroha features/flags; Issue: https://github.com/hyperledger/iroha-2-docs/issues/465 -->
+<!-- TODO: Link to a topic about Iroha features/flags; Issue: https://github.com/hyperledger-iroha/iroha-2-docs/issues/465 -->
 
 :::
 
@@ -406,7 +406,7 @@ A `GET` request to the endpoint.
 
 This operation requires the Iroha 2 network to be established with the `telemetry` feature enabled.
 
-<!-- TODO: Link to a topic about Iroha features/flags; Issue: https://github.com/hyperledger/iroha-2-docs/issues/465 -->
+<!-- TODO: Link to a topic about Iroha features/flags; Issue: https://github.com/hyperledger-iroha/iroha-2-docs/issues/465 -->
 
 :::
 
@@ -491,7 +491,7 @@ The following examples represent the same data:
 
 Almost all fields in the `Status` structure are 64-bit integers, and they are encoded in JSON as-is. Since native JSON's number type according to the specification effectively is `f64`, the precision might be lost on deserialization, for example, in [JavaScript's `JSON.parse`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/parse).
 
-For more details, see the related [GitHub issue](https://github.com/hyperledger/iroha/issues/3964).
+For more details, see the related [GitHub issue](https://github.com/hyperledger-iroha/iroha/issues/3964).
 
 :::
 


### PR DESCRIPTION
Iroha repositories were migrated from `hyperledger` organization  to `hyperledger-iroha`. This updates the links in the docs.