### PR TITLE
docs: update torii reference to reflect `rc.1`

### DIFF
--- a/.github/workflows/pull-request-ci.yaml
+++ b/.github/workflows/pull-request-ci.yaml
@@ -16,7 +16,9 @@ jobs:
       # https://github.com/pnpm/action-setup#use-cache-to-reduce-installation-time
 
       - name: Enable Corepack
-        run: corepack enable
+        run: |
+          npm i -g corepack@latest
+          corepack enable
 
       - name: Get pnpm store directory
         id: pnpm-cache

--- a/.github/workflows/pull-request-ci.yaml
+++ b/.github/workflows/pull-request-ci.yaml
@@ -10,7 +10,7 @@ jobs:
 
       - uses: actions/setup-node@v3
         with:
-          node-version: 18
+          node-version: 22
 
       # --- Install with caching
       # https://github.com/pnpm/action-setup#use-cache-to-reduce-installation-time

--- a/.vitepress/theme/index.ts
+++ b/.vitepress/theme/index.ts
@@ -10,7 +10,7 @@ import './style/index.scss'
 import { defineAsyncComponent } from 'vue'
 
 export default {
-  ...ThemeDefault,
+  extends: ThemeDefault,
   Layout: LayoutCustom,
   enhanceApp({ app }: EnhanceAppContext) {
     app.component('MermaidRenderWrap', MermaidRenderWrap)
@@ -23,4 +23,4 @@ export default {
       defineAsyncComponent(async () => import('./components/CompatibilityMatrixTableIcon.vue')),
     )
   },
-}
+} satisfies import('vitepress').Theme

--- a/etc/meta.ts
+++ b/etc/meta.ts
@@ -1,7 +1,4 @@
-/**
- * hyperledger-iroha/iroha#iroha2-dev
- */
-export const IROHA_REV_DEV = 'e7a605c1a926c319d214ef3825524ee6c2e9f076'
+export const IROHA_RC_1 = 'v2.0.0-rc.1.0'
 
 /**
  * hyperledger-iroha/iroha-javascript#iroha2 (rc13)

--- a/etc/schema/render.ts
+++ b/etc/schema/render.ts
@@ -3,8 +3,13 @@ import { match, P } from 'ts-pattern'
 // https://github.com/vuejs/vitepress/blob/b16340acbd3c60fee023daadb0ec5a0292060a1e/src/node/markdown/markdown.ts#L13
 import { slugify } from '@mdit-vue/shared'
 
+function typeSlug(type: string) {
+  if (type === '()') return `unit`
+  return slugify(type)
+}
+
 function segmentHeading(content: string) {
-  return `## ${code(content)}`
+  return `## ${code(content)} {#${typeSlug(content)}}`
 }
 
 function segmentPropNameOnly(prop: string) {
@@ -32,7 +37,7 @@ function tyMdLink(ty: string) {
       'String',
       (x) => `${code(x)}`,
     )
-    .otherwise((ty) => `[${code(ty)}](#${slugify(ty)})`)
+    .otherwise((ty) => `[${code(ty)}](#${typeSlug(ty)})`)
 }
 
 function code(content: string) {
@@ -97,7 +102,14 @@ function renderSegment(segment: Segment, segmentName: string): string {
         segmentType('Enum'),
         segmentPropNameOnly('Variants'),
         table(
-          [{ title: 'Variant name', align: 'right' }, { title: 'Variant value', align: 'left' }, 'Discriminant'],
+          [
+            { title: 'Variant name', align: 'right' },
+            {
+              title: 'Variant value',
+              align: 'left',
+            },
+            'Discriminant',
+          ],
           variants.map((x) => [code(x.tag), x.type ? tyMdLink(x.type) : `&mdash;`, String(x.discriminant)]),
           { indent: '  ' },
         ),

--- a/etc/snippet-sources.ts
+++ b/etc/snippet-sources.ts
@@ -1,5 +1,5 @@
 import type { SnippetSourceDefinition } from './types'
-import { IROHA_JAVA_REV_DEV, IROHA_JS_REV, IROHA_REV_DEV } from './meta'
+import { IROHA_JAVA_REV_DEV, IROHA_JS_REV, IROHA_RC_1 } from './meta'
 import { render as renderDataModelSchema } from './schema'
 
 // *****
@@ -102,11 +102,11 @@ const javascriptSnippets = [
 
 export default [
   {
-    src: `https://raw.githubusercontent.com/hyperledger-iroha/iroha/${IROHA_REV_DEV}/MAINTAINERS.md`,
+    src: `https://raw.githubusercontent.com/hyperledger-iroha/iroha/${IROHA_RC_1}/MAINTAINERS.md`,
     filename: 'iroha-maintainers.md',
   },
   {
-    src: `https://raw.githubusercontent.com/hyperledger-iroha/iroha/${IROHA_REV_DEV}/docs/source/references/schema.json`,
+    src: `https://raw.githubusercontent.com/hyperledger-iroha/iroha/${IROHA_RC_1}/docs/source/references/schema.json`,
     filename: `data-model-schema.md`,
     transform: (source) => {
       return renderDataModelSchema(JSON.parse(source))
@@ -116,18 +116,18 @@ export default [
     src: './src/example_code/lorem.rs',
   },
   {
-    src: `https://raw.githubusercontent.com/hyperledger-iroha/iroha/${IROHA_REV_DEV}/configs/client.template.toml`,
+    src: `https://raw.githubusercontent.com/hyperledger-iroha/iroha/${IROHA_RC_1}/docs/source/references/client.template.toml`,
     filename: 'client-cli-config-template.toml',
   },
   {
-    src: `https://raw.githubusercontent.com/hyperledger-iroha/iroha/${IROHA_REV_DEV}/configs/peer.template.toml`,
+    src: `https://raw.githubusercontent.com/hyperledger-iroha/iroha/${IROHA_RC_1}/docs/source/references/peer.template.toml`,
     filename: 'peer-config-template.toml',
   },
   {
-    src: `https://raw.githubusercontent.com/hyperledger-iroha/iroha/${IROHA_REV_DEV}/configs/swarm/genesis.json`,
+    src: `https://raw.githubusercontent.com/hyperledger-iroha/iroha/${IROHA_RC_1}/defaults/genesis.json`,
   },
   {
-    src: `https://raw.githubusercontent.com/hyperledger-iroha/iroha/${IROHA_REV_DEV}/client/examples/tutorial.rs`,
+    src: `https://raw.githubusercontent.com/hyperledger-iroha/iroha/${IROHA_RC_1}/crates/iroha/examples/tutorial.rs`,
     filename: 'tutorial-snippets.rs',
   },
 

--- a/src/reference/torii-endpoints.md
+++ b/src/reference/torii-endpoints.md
@@ -2,15 +2,26 @@
 
 ::: tip About Parity SCALE Codec
 
-Messages for certain `TORII` operations are encoded with the Parity <abbr title="Simple Concatenated Aggregate Little-Endian">SCALE</abbr> Codec (`SCALE`) commonly used with the [Parity Substrate](https://www.parity.io/technologies/substrate/) blockchain framework, and other blockchains utilizing it.
+Messages for certain `TORII` operations are encoded with the Parity
+<abbr title="Simple Concatenated Aggregate Little-Endian">SCALE</abbr> Codec
+(`SCALE`) commonly used with the
+[Parity Substrate](https://www.parity.io/technologies/substrate/) blockchain
+framework, and other blockchains utilizing it.
 
-For more information on `SCALE`, see the [Substrate Documentation: Type encoding (SCALE)](https://docs.substrate.io/reference/scale-codec/) article and its [official GitHub repository](https://github.com/paritytech/parity-scale-codec).
+For more information on `SCALE`, see the
+[Substrate Documentation: Type encoding (SCALE)](https://docs.substrate.io/reference/scale-codec/)
+article and its
+[official GitHub repository](https://github.com/paritytech/parity-scale-codec).
 
 <!-- TODO: link to our own article about SCALE, once it is written; Issue: https://github.com/hyperledger-iroha/iroha-2-docs/issues/367 -->
 
 :::
 
-Torii (Japanese: 鳥居 — Shinto shrine gateway) is the Iroha 2 module in charge of handling `HTTP` and `WebSocket` requests. It is the main <abbr title="Application Programming Interface">API</abbr> for interacting with Iroha 2. Such interactions include sending transactions, making queries, listening for blocks stream, etc.
+Torii (Japanese: 鳥居 — Shinto shrine gateway) is the Iroha 2 module in charge
+of handling `HTTP` and `WebSocket` requests. It is the main
+<abbr title="Application Programming Interface">API</abbr> for interacting with
+Iroha 2. Such interactions include sending transactions, making queries,
+listening for blocks stream, etc.
 
 <!-- TODO: Update the following as part of PR #397: https://github.com/hyperledger-iroha/iroha-2-docs/pull/397
 
@@ -40,11 +51,14 @@ To establish two-way communication with the `TORII` endpoints, the following add
 
 -->
 
+[[toc]]
+
 ## API Version
 
 ::: info
 
-This operation requires the specific Iroha node being requested to be compiled with the `telemetry` feature enabled.
+This operation requires the specific Iroha node being requested to be compiled
+with the `telemetry` feature enabled.
 
 <!-- TODO: Link to a topic about Iroha features/flags; Issue: https://github.com/hyperledger-iroha/iroha-2-docs/issues/465 -->
 
@@ -73,7 +87,10 @@ A `GET` request to the endpoint.
 
 ::: info
 
-The API version is retrieved from and is the same as the version of the [genesis block](../guide/configure/genesis.md), which means that at least a minimal subnet of four peers must be running, and the genesis block must already be submitted at the time of the request.
+The API version is retrieved from and is the same as the version of the
+[genesis block](../guide/configure/genesis.md), which means that at least a
+minimal subnet of four peers must be running, and the genesis block must already
+be submitted at the time of the request.
 
 :::
 
@@ -85,11 +102,20 @@ The API version is retrieved from and is the same as the version of the [genesis
 
 #### Handshake
 
-Since the `/block/stream` endpoint handles continuous two-way data exchange, a `WebSocket` handshake between the client and server must first be performed to initiate communication with this endpoint.
+Since the `/block/stream` endpoint handles continuous two-way data exchange, a
+`WebSocket` handshake between the client and server must first be performed to
+initiate communication with this endpoint.
 
 #### Data Exchange
 
-After establishing a `WebSocket` connection, the client must send a [`BlockSubscriptionRequest`](/reference/data-model-schema#blocksubscriptionrequest) request with the starting block number provided (i.e., the `height` value). Then, upon sending the confirmation and [`BlockMessage`](/reference/data-model-schema#blockmessage) messages, the server starts streaming all of the blocks, beginning with the block specified with `height` up to the most recent one, and then continues to stream new blocks as they are added to the blockchain.
+After establishing a `WebSocket` connection, the client must send a
+[`BlockSubscriptionRequest`](/reference/data-model-schema#blocksubscriptionrequest)
+request with the starting block number provided (i.e., the `height` value).
+Then, upon sending the confirmation and
+[`BlockMessage`](/reference/data-model-schema#blockmessage) messages, the server
+starts streaming all of the blocks, beginning with the block specified with
+`height` up to the most recent one, and then continues to stream new blocks as
+they are added to the blockchain.
 
 ## Configuration / Retrieve
 
@@ -120,7 +146,9 @@ A `GET` request to the endpoint.
 
 ::: info
 
-The subset of configuration parameters returned by this operation is equal to the one accepted by the [Configuration / Update](#configuration-update) operation, i.e., it only contains the `logger.level` parameter as of now.
+The subset of configuration parameters returned by this operation is equal to
+the one accepted by the [Configuration / Update](#configuration-update)
+operation, i.e., it only contains the `logger.level` parameter as of now.
 
 :::
 
@@ -133,15 +161,21 @@ The subset of configuration parameters returned by this operation is equal to th
 
 #### Requests
 
-This endpoint expects a subset of configuration parameters serialized into JSON format. Currently, it only supports dynamic updating of the `logger.level` parameter.
+This endpoint expects a subset of configuration parameters serialized into JSON
+format. Currently, it only supports dynamic updating of the `logger.level`
+parameter.
 
 ::: info
 
-The list of all accepted values is currently unavailable and will be a part of the configuration reference that is still <abbr title="Work in Progress">WIP</abbr>.
+The list of all accepted values is currently unavailable and will be a part of
+the configuration reference that is still
+<abbr title="Work in Progress">WIP</abbr>.
 
-Until then, to get assistance with the acceptable values and their definitions, consult [Receive Support](/help/) for ways to contact us.
+Until then, to get assistance with the acceptable values and their definitions,
+consult [Receive Support](/help/) for ways to contact us.
 
-The progress on the configuration reference can be tracked in the following GitHub issue:\
+The progress on the configuration reference can be tracked in the following
+GitHub issue:\
 [iroha-2-docs > Issue #392: Tracking issue for Configuration Reference as per RFC](https://github.com/hyperledger-iroha/iroha-2-docs/issues/392).
 
 :::
@@ -164,7 +198,10 @@ The progress on the configuration reference can be tracked in the following GitH
 
 ::: tip Guarantees
 
-A successful configuration update does not guarantee that the configuration is indeed updated. While a follow-up [Configuration / Retrieve](#configuration-retrieve) request will return updated values, the actual update is performed asynchronously.
+A successful configuration update does not guarantee that the configuration is
+indeed updated. While a follow-up
+[Configuration / Retrieve](#configuration-retrieve) request will return updated
+values, the actual update is performed asynchronously.
 
 :::
 
@@ -178,21 +215,37 @@ A successful configuration update does not guarantee that the configuration is i
 
 The status of a transaction event can be one of the following:
 
-- `Validating` — The transaction has been successfully submitted and is currently being validated by peers.
-- `Committed` — The transaction has been successfully validated and is committed to the blockchain.
-- `Rejected` — The transaction has been rejected by at least one peer and is __not__ committed to the blockchain.
+- `Validating` — The transaction has been successfully submitted and is
+  currently being validated by peers.
+- `Committed` — The transaction has been successfully validated and is committed
+  to the blockchain.
+- `Rejected` — The transaction has been rejected by at least one peer and is
+  **not** committed to the blockchain.
 
-All transactions are designated with the `Validating` status upon creation, which later proceeds to either `Committed` or `Rejected`. However, due to the distributed nature of the network, some peers might receive events out of order (e.g., `Committed` before `Validating`).
+All transactions are designated with the `Validating` status upon creation,
+which later proceeds to either `Committed` or `Rejected`. However, due to the
+distributed nature of the network, some peers might receive events out of order
+(e.g., `Committed` before `Validating`).
 
-Some peers in the network may be offline for the validation round. If a client connects to them while they are offline, the peers might not respond with the `Validating` status. But when the offline peers come back online they will automatically synchronize the blocks. These peers are then guaranteed to respond with either `Committed` or `Rejected` status, depending on the information found in the block.
+Some peers in the network may be offline for the validation round. If a client
+connects to them while they are offline, the peers might not respond with the
+`Validating` status. But when the offline peers come back online they will
+automatically synchronize the blocks. These peers are then guaranteed to respond
+with either `Committed` or `Rejected` status, depending on the information found
+in the block.
 
 #### Handshake
 
-Since the `/events` endpoint handles continuous two-way data exchange, a `WebSocket` handshake between the client and server must first be performed to initiate communication with this endpoint.
+Since the `/events` endpoint handles continuous two-way data exchange, a
+`WebSocket` handshake between the client and server must first be performed to
+initiate communication with this endpoint.
 
 #### Data Exchange
 
-After establishing a `WebSocket` connection, the client must send an [`EventSubscriptionRequest`](/reference/data-model-schema#eventsubscriptionrequest) request, after which the server sends an [`EventMessage`](/reference/data-model-schema#eventmessage) response.
+After establishing a `WebSocket` connection, the client must send an
+[`EventSubscriptionRequest`](/reference/data-model-schema#eventsubscriptionrequest)
+request, after which the server sends an
+[`EventMessage`](/reference/data-model-schema#eventmessage) response.
 
 ## Health
 
@@ -217,11 +270,105 @@ A `GET` request to the endpoint.
 "Healthy"
 ```
 
-## Metrics
+## Query
+
+- **Protocol**: `HTTP`
+- **Method**: `POST`
+- **Encoding**: `SCALE`
+- **Endpoint**: `/query`
+
+#### Requests
+
+This endpoint expects requests with two shapes:
+
+Start a query:
+
+- **Body**: [`SignedQuery`](/reference/data-model-schema#signedquery)
+
+OR
+
+Get the next batch of a previously started query:
+
+- **Parameters**:
+  - `cursor` - specifies a cursor previously returned as part of query response
+
+Request
+
+#### Responses
+
+| Code | Response                        | Body                                                                                               | Description                                                                |
+| :--: | ------------------------------- | -------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
+| 200  | Success                         | [`BatchedResponse<QueryOutputBox>`](/reference/data-model-schema#batchedresponse-queryoutputbox)   | Successful query request                                                   |
+| 400  | Conversion Error                | [`QueryExecutionFail::Conversion(String)`](/reference/data-model-schema#queryexecutionfail)        | Invalid asset query for the actual asset type                              |
+| 400  | Cursor Error                    | [`QueryExecutionFail::UnknownCursor`](/reference/data-model-schema#queryexecutionfail)             | An invalid cursor was provided in the batch request                        |
+| 400  | FetchSizeTooBig Error           | [`QueryExecutionFail::FetchSizeTooBig`](/reference/data-model-schema#queryexecutionfail)           | Fetch size specified in the query request is too large                     |
+| 400  | InvalidSingularParameters Error | [`QueryExecutionFail::InvalidSingularParameters`](/reference/data-model-schema#queryexecutionfail) | Specified query parameters are not applicable to the (singular) query type |
+| 401  | Signature Error                 | [`QueryExecutionFail::Signature(String)`](/reference/data-model-schema#queryexecutionfail)         | The signature on the query is incorrect                                    |
+| 403  | Permission Error                | [`QueryExecutionFail::Permission(String)`](/reference/data-model-schema#queryexecutionfail)        | The user does not have permission to execute this query                    |
+| 404  | Find Error                      | [`QueryExecutionFail::Find(FindError)`](/reference/data-model-schema#queryexecutionfail)           | The queried object was not found                                           |
 
 ::: info
 
-This operation requires the Iroha 2 network to be established with the `telemetry` feature enabled.
+The `200 Success` response returns results that are ordered by `id`, which use
+Rust's [PartialOrd](https://doc.rust-lang.org/std/cmp/trait.PartialOrd.html) and
+[Ord](https://doc.rust-lang.org/std/cmp/trait.Ord.html) traits.
+
+:::
+
+### Account Not Found 404
+
+Whether each prerequisite object was found and
+[`FindError`](/reference/data-model-schema#finderror):
+
+| Domain | Account | [`FindError`](/reference/data-model-schema#finderror)                     |
+| :----: | :-----: | ------------------------------------------------------------------------- |
+|   N    |    -    | [`FindError::Domain(DomainId)`](/reference/data-model-schema#finderror)   |
+|   Y    |    N    | [`FindError::Account(AccountId)`](/reference/data-model-schema#finderror) |
+
+### Asset Not Found 404
+
+Whether each prerequisite object was found and
+[`FindError`](/reference/data-model-schema#finderror):
+
+| Domain | Account | Asset Definition | Asset | [`FindError`](/reference/data-model-schema#finderror)                                     |
+| :----: | :-----: | :--------------: | :---: | ----------------------------------------------------------------------------------------- |
+|   N    |    -    |        -         |   -   | [`FindError::Domain(DomainId)`](/reference/data-model-schema#finderror)                   |
+|   Y    |    N    |        -         |   -   | [`FindError::Account(AccountId)`](/reference/data-model-schema#finderror)                 |
+|   Y    |    -    |        N         |   -   | [`FindError::AssetDefinition(AssetDefinitionId)`](/reference/data-model-schema#finderror) |
+|   Y    |    Y    |        Y         |   N   | [`FindError::Asset(AssetId)`](/reference/data-model-schema#finderror)                     |
+
+## Schema <Badge text="feature: schema" type=tip />
+
+::: info
+
+This operation requires the Iroha 2 network to be established with the `schema`
+feature enabled.
+
+<!-- TODO: Link to a topic about Iroha features/flags; Issue: https://github.com/hyperledger-iroha/iroha-2-docs/issues/465 -->
+
+:::
+
+- **Protocol**: `HTTP`
+- **Method**: `GET`
+- **Encoding**: `JSON`
+- **Endpoint**: `/schema`
+
+#### Requests
+
+A `GET` request to the endpoint.
+
+#### Responses
+
+| Code | Response | Description                                                                                                         |
+| :--: | -------- | ------------------------------------------------------------------------------------------------------------------- |
+| 200  | OK       | Returns the Rust data structures and types of the entire [Data Model Schema](data-model-schema.md) as JSON objects. |
+
+## Telemetry / Metrics <Badge text="feature: telemetry" type=tip />
+
+::: info
+
+This operation requires the Iroha 2 network to be established with the
+`telemetry` feature enabled.
 
 <!-- TODO: Link to a topic about Iroha features/flags; Issue: https://github.com/hyperledger-iroha/iroha-2-docs/issues/465 -->
 
@@ -293,102 +440,12 @@ To learn more about metrics, see [Metrics](../guide/advanced/metrics.md).
 
 :::
 
-## Pending Transactions
-
-- **Protocol**: `HTTP`
-- **Method**: `GET`
-- **Encoding**: `SCALE`
-- **Endpoint**: `/pending_transactions`
-
-#### Requests
-
-A `GET` request to the endpoint.
-
-#### Responses
-
-| Code | Response | Description                                                                                                                                                          |
-| :--: | -------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| 200  | OK       | Returns a list of pending transactions as [`SignedTransaction`](data-model-schema.md#signedtransaction) objects encoded with `SCALE`; must be decoded by the client. |
-
-## Query
-
-- **Protocol**: `HTTP`
-- **Method**: `POST`
-- **Encoding**: `SCALE`
-- **Endpoint**: `/query`
-
-#### Requests
-
-This endpoint expects requests with two shapes:
-
-Start a query:
-
-- **Body**: [`SignedQuery`](/reference/data-model-schema#signedquery)
-
-OR
-
-Get the next batch of a previously started query:
-
-- **Parameters**:
-    - `cursor` - specifies a cursor previously returned as part of query response
-
-Request
-
-#### Responses
-
-| Code | Response                        | Body                                                                                               | Description                                                                |
-|:----:|---------------------------------|----------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------|
-| 200  | Success                         | [`BatchedResponse<QueryOutputBox>`](/reference/data-model-schema#batchedresponse-queryoutputbox)   | Successful query request                                                   |
-| 400  | Conversion Error                | [`QueryExecutionFail::Conversion(String)`](/reference/data-model-schema#queryexecutionfail)        | Invalid asset query for the actual asset type                              |
-| 400  | Cursor Error                    | [`QueryExecutionFail::UnknownCursor`](/reference/data-model-schema#queryexecutionfail)             | An invalid cursor was provided in the batch request                        |
-| 400  | FetchSizeTooBig Error           | [`QueryExecutionFail::FetchSizeTooBig`](/reference/data-model-schema#queryexecutionfail)           | Fetch size specified in the query request is too large                     |
-| 400  | InvalidSingularParameters Error | [`QueryExecutionFail::InvalidSingularParameters`](/reference/data-model-schema#queryexecutionfail) | Specified query parameters are not applicable to the (singular) query type |
-| 401  | Signature Error                 | [`QueryExecutionFail::Signature(String)`](/reference/data-model-schema#queryexecutionfail)         | The signature on the query is incorrect                                    |
-| 403  | Permission Error                | [`QueryExecutionFail::Permission(String)`](/reference/data-model-schema#queryexecutionfail)        | The user does not have permission to execute this query                    |
-| 404  | Find Error                      | [`QueryExecutionFail::Find(FindError)`](/reference/data-model-schema#queryexecutionfail)           | The queried object was not found                                           |
-
-::: info
-
-The `200 Success` response returns results that are ordered by `id`, which use
-Rust's [PartialOrd](https://doc.rust-lang.org/std/cmp/trait.PartialOrd.html)
-and [Ord](https://doc.rust-lang.org/std/cmp/trait.Ord.html) traits.
-
-:::
-
-### Account Not Found 404
-
-Whether each prerequisite object was found and [`FindError`](/reference/data-model-schema#finderror):
-
-| Domain | Account | [`FindError`](/reference/data-model-schema#finderror)                     |
-| :----: | :-----: | ------------------------------------------------------------------------- |
-|   N    |    -    | [`FindError::Domain(DomainId)`](/reference/data-model-schema#finderror)   |
-|   Y    |    N    | [`FindError::Account(AccountId)`](/reference/data-model-schema#finderror) |
-
-### Asset Not Found 404
-
-Whether each prerequisite object was found and [`FindError`](/reference/data-model-schema#finderror):
-
-| Domain | Account | Asset Definition | Asset | [`FindError`](/reference/data-model-schema#finderror)                                     |
-| :----: | :-----: | :--------------: | :---: | ----------------------------------------------------------------------------------------- |
-|   N    |    -    |        -         |   -   | [`FindError::Domain(DomainId)`](/reference/data-model-schema#finderror)                   |
-|   Y    |    N    |        -         |   -   | [`FindError::Account(AccountId)`](/reference/data-model-schema#finderror)                 |
-|   Y    |    -    |        N         |   -   | [`FindError::AssetDefinition(AssetDefinitionId)`](/reference/data-model-schema#finderror) |
-|   Y    |    Y    |        Y         |   N   | [`FindError::Asset(AssetId)`](/reference/data-model-schema#finderror)                     |
-
-## Schema
-
-::: info
-
-This operation requires the Iroha 2 network to be established with the `schema` feature enabled.
-
-<!-- TODO: Link to a topic about Iroha features/flags; Issue: https://github.com/hyperledger-iroha/iroha-2-docs/issues/465 -->
-
-:::
+## Telemetry / Peers <Badge text="feature: telemetry" type=tip />
 
 - **Protocol**: `HTTP`
 - **Method**: `GET`
 - **Encoding**: `JSON`
-- **Endpoint**: `/schema`
+- **Endpoint**: `/peers`
 
 #### Requests
 
@@ -396,15 +453,27 @@ A `GET` request to the endpoint.
 
 #### Responses
 
-| Code | Response | Description                                                                                                         |
-| :--: | -------- | ------------------------------------------------------------------------------------------------------------------- |
-| 200  | OK       | Returns the Rust data structures and types of the entire [Data Model Schema](data-model-schema.md) as JSON objects. |
+| Code | Response             |
+| ---- | -------------------- |
+| 200  | List of online peers |
 
-## Status
+**Example:**
+
+```json
+[
+  {
+    "address": "0.0.0.0:8081",
+    "id": "ed0120B23E14F659B91736AAB980B6ADDCE4B1DB8A138AB0267E049C082A744471714E"
+  }
+]
+```
+
+## Telemetry / Status <Badge text="feature: telemetry" type=tip />
 
 ::: info
 
-This operation requires the Iroha 2 network to be established with the `telemetry` feature enabled.
+This operation requires the Iroha 2 network to be established with the
+`telemetry` feature enabled.
 
 <!-- TODO: Link to a topic about Iroha features/flags; Issue: https://github.com/hyperledger-iroha/iroha-2-docs/issues/465 -->
 
@@ -421,18 +490,20 @@ A `GET` request to the endpoint.
 
 This endpoint also accepts the following:
 
-  - **Header**: Specifies the encoding of the retrieved data.\
+- **Header**: Specifies the encoding of the retrieved data.\
   Can be set to one of the following:
-    - `Accept: application/x-parity-scale` — the retrieved data is encoded with `SCALE`.
-    - `Accept: application/json` — the retrieved data is encoded with `JSON`.
+  - `Accept: application/x-parity-scale` — the retrieved data is encoded with
+    `SCALE`.
+  - `Accept: application/json` — the retrieved data is encoded with `JSON`.
 
-If no header is specified in the request, the `Accept: application/json` header is used by default.
+If no header is specified in the request, the `Accept: application/json` header
+is used by default.
 
 #### Responses
 
-| Code | Response              | Description                                                                                |
-| :--: | --------------------- | ------------------------------------------------------------------------------------------ |
-| 200  | Iroha Status          | Returns the Iroha network status report encoded as specified in the header of the request. |
+| Code | Response     | Description                                                                                |
+| :--: | ------------ | ------------------------------------------------------------------------------------------ |
+| 200  | Iroha Status | Returns the Iroha network status report encoded as specified in the header of the request. |
 
 The response body has the following structure:
 
@@ -489,21 +560,29 @@ The following examples represent the same data:
 
 ::: warning JSON Precision Lost
 
-Almost all fields in the `Status` structure are 64-bit integers, and they are encoded in JSON as-is. Since native JSON's number type according to the specification effectively is `f64`, the precision might be lost on deserialization, for example, in [JavaScript's `JSON.parse`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/parse).
+Almost all fields in the `Status` structure are 64-bit integers, and they are
+encoded in JSON as-is. Since native JSON's number type according to the
+specification effectively is `f64`, the precision might be lost on
+deserialization, for example, in
+[JavaScript's `JSON.parse`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/parse).
 
-For more details, see the related [GitHub issue](https://github.com/hyperledger-iroha/iroha/issues/3964).
+For more details, see the related
+[GitHub issue](https://github.com/hyperledger-iroha/iroha/issues/3964).
 
 :::
 
 ::: tip Compact Form in SCALE
 
-Fields with `u64` type are serialized in the [Compact form](https://docs.substrate.io/reference/scale-codec/#fn-1).
+Fields with `u64` type are serialized in the
+[Compact form](https://docs.substrate.io/reference/scale-codec/#fn-1).
 
 :::
 
 ### Sub-routing
 
-It is also possible to retrieve the data of a specific `struct` group or variable within it by adding their path to the endpoint address. The sub-routed values are only returned in the JSON format.
+It is also possible to retrieve the data of a specific `struct` group or
+variable within it by adding their path to the endpoint address. The sub-routed
+values are only returned in the JSON format.
 
 **Examples**:
 
@@ -552,7 +631,8 @@ It is also possible to retrieve the data of a specific `struct` group or variabl
 
 This endpoint expects the following data:
 
-  - **Body**: [`SignedTransaction`](/reference/data-model-schema#signedtransaction)
+- **Body**:
+  [`SignedTransaction`](/reference/data-model-schema#signedtransaction)
 
 #### Responses
 

--- a/src/reference/torii-endpoints.md
+++ b/src/reference/torii-endpoints.md
@@ -69,9 +69,6 @@ with the `telemetry` feature enabled.
 - **Encoding**: `JSON`
 - **Endpoint**: `/api_version`
 
-#### Requests
-
-A `GET` request to the endpoint.
 
 #### Responses
 
@@ -81,8 +78,8 @@ A `GET` request to the endpoint.
 
 **Example**:
 
-```json
-"1"
+```
+1
 ```
 
 ::: info
@@ -123,10 +120,6 @@ they are added to the blockchain.
 - **Method**: `GET`
 - **Encoding**: `JSON`
 - **Endpoint**: `/configuration`
-
-#### Requests
-
-A `GET` request to the endpoint.
 
 #### Responses
 
@@ -196,15 +189,6 @@ GitHub issue:\
 | :--: | -------- | ------------------------------------------------------------------------------- |
 | 202  | Accepted | The request to update the configuration is accepted and is due to be processed. |
 
-::: tip Guarantees
-
-A successful configuration update does not guarantee that the configuration is
-indeed updated. While a follow-up
-[Configuration / Retrieve](#configuration-retrieve) request will return updated
-values, the actual update is performed asynchronously.
-
-:::
-
 ## Events
 
 - **Protocols**: `HTTP` upgraded to `WebSocket`
@@ -254,10 +238,6 @@ request, after which the server sends an
 - **Encoding**: `JSON`
 - **Endpoint**: `/health`
 
-#### Requests
-
-A `GET` request to the endpoint.
-
 #### Responses
 
 | Code | Response      | Description                                                    |
@@ -266,8 +246,8 @@ A `GET` request to the endpoint.
 
 **Example**:
 
-```json
-"Healthy"
+```
+Healthy
 ```
 
 ## Query
@@ -279,26 +259,13 @@ A `GET` request to the endpoint.
 
 #### Requests
 
-This endpoint expects requests in two formats:
-
-Start a query:
-
-- **Body**: [`SignedQuery`](/reference/data-model-schema#signedquery)
-
-OR
-
-Get the next batch of a previously started query:
-
-- **Parameters**:
-  - `cursor` - specifies a cursor previously returned as part of query response
-
-Request
+This endpoint expects [`SignedQuery`](/reference/data-model-schema#signedquery) as a request body.
 
 #### Responses
 
 | Code | Response                        | Body                                                                                               | Description                                                                |
 | :--: | ------------------------------- | -------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
-| 200  | Success                         | [`BatchedResponse<QueryOutputBox>`](/reference/data-model-schema#batchedresponse-queryoutputbox)   | Successful query request                                                   |
+| 200  | Success                         | [`QueryResponse`](/reference/data-model-schema#queryresponse)   | Successful query request                                                   |
 | 400  | Conversion Error                | [`QueryExecutionFail::Conversion(String)`](/reference/data-model-schema#queryexecutionfail)        | Invalid asset query for the actual asset type                              |
 | 400  | Cursor Error                    | [`QueryExecutionFail::UnknownCursor`](/reference/data-model-schema#queryexecutionfail)             | An invalid cursor was provided in the batch request                        |
 | 400  | FetchSizeTooBig Error           | [`QueryExecutionFail::FetchSizeTooBig`](/reference/data-model-schema#queryexecutionfail)           | Fetch size specified in the query request is too large                     |

--- a/src/reference/torii-endpoints.md
+++ b/src/reference/torii-endpoints.md
@@ -363,7 +363,7 @@ A `GET` request to the endpoint.
 | :--: | -------- | ------------------------------------------------------------------------------------------------------------------- |
 | 200  | OK       | Returns the Rust data structures and types of the entire [Data Model Schema](data-model-schema.md) as JSON objects. |
 
-## Telemetry / Metrics <Badge text="feature: telemetry" type=tip />
+## Telemetry / Metrics <Badge text="feature: telemetry" type=tip /> {#metrics}
 
 ::: info
 

--- a/src/reference/torii-endpoints.md
+++ b/src/reference/torii-endpoints.md
@@ -279,7 +279,7 @@ A `GET` request to the endpoint.
 
 #### Requests
 
-This endpoint expects requests with two shapes:
+This endpoint expects requests in two formats:
 
 Start a query:
 
@@ -317,7 +317,7 @@ Rust's [PartialOrd](https://doc.rust-lang.org/std/cmp/trait.PartialOrd.html) and
 
 ### Account Not Found 404
 
-Whether each prerequisite object was found and
+The following table shows which error you will get depending on which prerequisite object could not be found
 [`FindError`](/reference/data-model-schema#finderror):
 
 | Domain | Account | [`FindError`](/reference/data-model-schema#finderror)                     |
@@ -327,7 +327,7 @@ Whether each prerequisite object was found and
 
 ### Asset Not Found 404
 
-Whether each prerequisite object was found and
+The following table shows which error you will get depending on which prerequisite object could not be found
 [`FindError`](/reference/data-model-schema#finderror):
 
 | Domain | Account | Asset Definition | Asset | [`FindError`](/reference/data-model-schema#finderror)                                     |

--- a/src/reference/torii-endpoints.md
+++ b/src/reference/torii-endpoints.md
@@ -69,7 +69,6 @@ with the `telemetry` feature enabled.
 - **Encoding**: `JSON`
 - **Endpoint**: `/api_version`
 
-
 #### Responses
 
 | Code | Response | Description                                                                                 |
@@ -259,20 +258,26 @@ Healthy
 
 #### Requests
 
-This endpoint expects [`SignedQuery`](/reference/data-model-schema#signedquery) as a request body.
+This endpoint expects [`SignedQuery`](/reference/data-model-schema#signedquery)
+as a request body.
 
 #### Responses
 
-| Code | Response                        | Body                                                                                               | Description                                                                |
-| :--: | ------------------------------- | -------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
-| 200  | Success                         | [`QueryResponse`](/reference/data-model-schema#queryresponse)   | Successful query request                                                   |
-| 400  | Conversion Error                | [`QueryExecutionFail::Conversion(String)`](/reference/data-model-schema#queryexecutionfail)        | Invalid asset query for the actual asset type                              |
-| 400  | Cursor Error                    | [`QueryExecutionFail::UnknownCursor`](/reference/data-model-schema#queryexecutionfail)             | An invalid cursor was provided in the batch request                        |
-| 400  | FetchSizeTooBig Error           | [`QueryExecutionFail::FetchSizeTooBig`](/reference/data-model-schema#queryexecutionfail)           | Fetch size specified in the query request is too large                     |
-| 400  | InvalidSingularParameters Error | [`QueryExecutionFail::InvalidSingularParameters`](/reference/data-model-schema#queryexecutionfail) | Specified query parameters are not applicable to the (singular) query type |
-| 401  | Signature Error                 | [`QueryExecutionFail::Signature(String)`](/reference/data-model-schema#queryexecutionfail)         | The signature on the query is incorrect                                    |
-| 403  | Permission Error                | [`QueryExecutionFail::Permission(String)`](/reference/data-model-schema#queryexecutionfail)        | The user does not have permission to execute this query                    |
-| 404  | Find Error                      | [`QueryExecutionFail::Find(FindError)`](/reference/data-model-schema#queryexecutionfail)           | The queried object was not found                                           |
+- 200
+  - [`QueryResponse`](/reference/data-model-schema#queryresponse)
+  - Successful query request
+
+| Code | Response                         | Body                                                            | Description                                                                |
+| :--: | -------------------------------- | --------------------------------------------------------------- | -------------------------------------------------------------------------- |
+| 200  | Success                          | [`QueryResponse`](/reference/data-model-schema#queryresponse)   | Successful query request                                                   |
+| 400  | Conversion Error                 | [`ValidationFail`](/reference/data-model-schema#validationfail) | Invalid asset query for the actual asset type                              |
+| 400  | CursorMismatch/CursorDone Errors | [`ValidationFail`](/reference/data-model-schema#validationfail) | An invalid cursor was provided in the batch request                        |
+| 400  | FetchSizeTooBig Error            | [`ValidationFail`](/reference/data-model-schema#validationfail) | Fetch size specified in the query request is too large                     |
+| 400  | InvalidSingularParameters Error  | [`ValidationFail`](/reference/data-model-schema#validationfail) | Specified query parameters are not applicable to the (singular) query type |
+| 400  | CapacityLimit Error              | [`ValidationFail`](/reference/data-model-schema#validationfail) | Reached the limit of parallel queries                                      |
+| 401  | Signature Error                  | [`ValidationFail`](/reference/data-model-schema#validationfail) | The signature on the query is incorrect                                    |
+| 403  | Permission Error                 | [`ValidationFail`](/reference/data-model-schema#validationfail) | The user does not have permission to execute this query                    |
+| 404  | Find Error                       | [`ValidationFail`](/reference/data-model-schema#validationfail) | The queried object was not found                                           |
 
 ::: info
 
@@ -282,9 +287,17 @@ Rust's [PartialOrd](https://doc.rust-lang.org/std/cmp/trait.PartialOrd.html) and
 
 :::
 
+::: tip
+
+See [`QueryExecutionFail`](/reference/data-model-schema#queryexecutionfail) type
+for details of the errors.
+
+:::
+
 ### Account Not Found 404
 
-The following table shows which error you will get depending on which prerequisite object could not be found
+The following table shows which error you will get depending on which
+prerequisite object could not be found
 [`FindError`](/reference/data-model-schema#finderror):
 
 | Domain | Account | [`FindError`](/reference/data-model-schema#finderror)                     |
@@ -294,7 +307,8 @@ The following table shows which error you will get depending on which prerequisi
 
 ### Asset Not Found 404
 
-The following table shows which error you will get depending on which prerequisite object could not be found
+The following table shows which error you will get depending on which
+prerequisite object could not be found
 [`FindError`](/reference/data-model-schema#finderror):
 
 | Domain | Account | Asset Definition | Asset | [`FindError`](/reference/data-model-schema#finderror)                                     |


### PR DESCRIPTION
- Removed "pending transactions" endpoint
- Added Telemetry > Peers endpoint
- Grouped telemetry endpoints, renamed to "Telemetry / ..."
- Added feature badges (without explanations though) to indicate which Iroha compile features enable certain endpoints.